### PR TITLE
Bugfix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -142,11 +142,8 @@ namespace HDD_Ping
         {
           var interval = timerItems[s as MenuItem];
           settings.Interval = TimeSpan.FromMinutes(interval);
-          
-          this.timer.Enabled = false;
-          this.timer.Stop();
-          this.timer.Dispose();
-          this.InitializeTimer(settings.Interval);
+
+          this.timer.Interval = settings.Interval.TotalMilliseconds;
 
           foreach (var ti in timerItems)
           {

--- a/Program.cs
+++ b/Program.cs
@@ -74,7 +74,7 @@ namespace HDD_Ping
         this.SwitchToWorkingIcon();
       }
 
-      foreach (var ds in settings.DriveSettings)
+      foreach (var ds in settings.DriveSettings.Where(ds => ds.Ping))
       {
         var guid = Guid.NewGuid().ToString();
         try


### PR DESCRIPTION
I've started to modify this repo to use seconds instead of minutes and to use LBA level reandom direct disk reads instead of file writes.

And I've found 2 bugs in it (this PR is only about the bugs):
- Ping only drives that are selected
- Don't recreate timer (even after disposing, the original kept firing when I've tested it, causing multiple parallel pings)
