### PR TITLE
Use seconds, not only minutes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -132,10 +132,10 @@ namespace HDD_Ping
 
       var timerMenu = new MenuItem("Interval");
       var timerItems = new Dictionary<MenuItem, int>();
-      int[] seconds = { 1, 2, 5, 10, 15, 20, 30, 45, 60 };
+      int[] seconds = { 1, 2, 5, 10, 15, 20, 30, 45, 60, 90, 120, 300 };
       foreach (var i in seconds)
       {
-        var tSec = new MenuItem(String.Format("{0} {1}", i, i == 1 ? "Second" : "Seconds"))
+        var tSec = new MenuItem(String.Format("{0} {1}", i < 60 ? i : (float)i / 60.0F, i == 1 ? "Second" : i < 60 ? "Seconds" : i < 120 ? "Minute" : "Minutes"))
         {
           Checked = (int)settings.Interval.TotalSeconds == i
         };

--- a/Program.cs
+++ b/Program.cs
@@ -132,16 +132,17 @@ namespace HDD_Ping
 
       var timerMenu = new MenuItem("Interval");
       var timerItems = new Dictionary<MenuItem, int>();
-      foreach (var i in Enumerable.Range(1, 25))
+      int[] seconds = { 1, 2, 5, 10, 15, 20, 30, 45, 60 };
+      foreach (var i in seconds)
       {
-        var tMin = new MenuItem(String.Format("{0} {1}", i, i == 1 ? "Minute" : "Minutes"))
+        var tSec = new MenuItem(String.Format("{0} {1}", i, i == 1 ? "Second" : "Seconds"))
         {
-          Checked = (int)settings.Interval.TotalMinutes == i
+          Checked = (int)settings.Interval.TotalSeconds == i
         };
-        tMin.Click += (s, e) =>
+        tSec.Click += (s, e) =>
         {
           var interval = timerItems[s as MenuItem];
-          settings.Interval = TimeSpan.FromMinutes(interval);
+          settings.Interval = TimeSpan.FromSeconds(interval);
 
           this.timer.Interval = settings.Interval.TotalMilliseconds;
 
@@ -152,8 +153,8 @@ namespace HDD_Ping
           (s as MenuItem).Checked = true;
         };
 
-        timerItems.Add(tMin, i);
-        timerMenu.MenuItems.Add(tMin);
+        timerItems.Add(tSec, i);
+        timerMenu.MenuItems.Add(tSec);
       }
 
       trayIcon.ContextMenu.MenuItems.Add(timerMenu);
@@ -182,7 +183,7 @@ namespace HDD_Ping
     {
       trayIcon.Icon = Properties.Resources.working;
 
-      Task.Delay(5000).ContinueWith(finishedTask =>
+      Task.Delay(Math.Min((int)settings.Interval.TotalMilliseconds / 3, 5000)).ContinueWith(finishedTask =>
       {
         this.SetStateIcon();
       });
@@ -242,7 +243,7 @@ namespace HDD_Ping
   {
     public const string ConfigFile = ".settings.ser";
 
-    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(5);
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
 
     public TimeSpan Interval { get; set; }
 


### PR DESCRIPTION
The original 1..25 minute interval list is too slow for newer HDDs, eg. my Toshiba MQ04 parks it's heads after 60 sec, even when APM is 254! I'm using 45s interval, and it's fine.

This is how the menu changes from this PR:
![image](https://user-images.githubusercontent.com/5061219/149243415-22a69183-7313-4fcf-9cda-865b541a6327.png)

This PR is cherry picked from my fork, basically only the random direct disk reads are missing, but that requires admin privilege and I think it only provides minimal benefit to not write the same directory entry on the disk, but randomly read the whole surface. (Creating a 0 length file I think only modifies the directory entries.)
